### PR TITLE
New slaved axis method

### DIFF
--- a/ConfigSamples/config-cnc.ini
+++ b/ConfigSamples/config-cnc.ini
@@ -52,9 +52,7 @@ gamma.acceleration = 500    # overrides the default acceleration for this axis
 gamma.microsteps = 32       # sets micro stepping (default 32)
 
 # example where the motor 4 is slaved to motor 1 (Y)
-#delta.steps_per_mm = 800    # Steps per mm for delta ( Z ) stepper
-#delta.max_rate = 1800      # Maximum rate in mm/min
-#delta.microsteps = 32       # sets micro stepping (default 32)
+#delta.microsteps = 32       # sets micro stepping (default 32) must be same as master actuator
 #delta.slaved_to = beta      # delta is slaved to beta(Y)
 
 common.check_driver_errors = true     # set to true means the driver (tmc2660) error bits are checked

--- a/ConfigSamples/config-delta.ini
+++ b/ConfigSamples/config-delta.ini
@@ -78,9 +78,9 @@ common.halt_on_driver_alarm = false   # if set to true means ON_HALT is entered 
 # common settings for all tmc2660 drivers
 
 # settings specific to each tmc2660 driver instance
-alpha.step_interpolation = true # set to true to turn on the step interpolation
-beta.step_interpolation = true  # set to true to turn on the step interpolation
-gamma.step_interpolation = true # set to true to turn on the step interpolation
+alpha.step_interpolation = false # set to true to turn on the step interpolation
+beta.step_interpolation = false  # set to true to turn on the step interpolation
+gamma.step_interpolation = false # set to true to turn on the step interpolation
 delta.step_interpolation = false # set to true to turn on the step interpolation
 
 # Usually set to 50% to 75% of peak current

--- a/ConfigSamples/config-lathe.ini
+++ b/ConfigSamples/config-lathe.ini
@@ -67,9 +67,9 @@ common.halt_on_driver_alarm = false   # if set to true means ON_HALT is entered 
 #common.reset_pin = ???        # Not on prime but some external boards may have one
 
 # settings specific to each tmc2590 driver instance
-alpha.step_interpolation = true  # set to true to turn on the step interpolation
-beta.step_interpolation = true   # set to true to turn on the step interpolation
-gamma.step_interpolation = true  # set to true to turn on the step interpolation
+alpha.step_interpolation = false  # set to true to turn on the step interpolation
+beta.step_interpolation = false   # set to true to turn on the step interpolation
+gamma.step_interpolation = false  # set to true to turn on the step interpolation
 delta.step_interpolation = false # set to true to turn on the step interpolation
 
 # Usually set to 50% to 75% of peak current
@@ -101,9 +101,9 @@ delta.standstill_current = 0     # set the standstill current in mA, 0 is disabl
 #common.standstill_time = 10   # time interval to check for standstill to reduce current in seconds
 
 # settings specific to each tmc2660 driver instance
-alpha.step_interpolation = true # set to true to turn on the step interpolation
-beta.step_interpolation = true  # set to true to turn on the step interpolation
-gamma.step_interpolation = true # set to true to turn on the step interpolation
+alpha.step_interpolation = false # set to true to turn on the step interpolation
+beta.step_interpolation = false  # set to true to turn on the step interpolation
+gamma.step_interpolation = false # set to true to turn on the step interpolation
 delta.step_interpolation = false # set to true to turn on the step interpolation
 
 # Usually set to 50% to 75% of peak current

--- a/ConfigSamples/minimal.ini
+++ b/ConfigSamples/minimal.ini
@@ -63,16 +63,16 @@ common.halt_on_driver_alarm = false   # if set to true means ON_HALT is entered 
 
 [tmc2590]
 # settings specific to each tmc2590 driver instance
-alpha.step_interpolation = true # set to true to turn on the step interpolation
-beta.step_interpolation = true  # set to true to turn on the step interpolation
-gamma.step_interpolation = true # set to true to turn on the step interpolation
+alpha.step_interpolation = false # set to true to turn on the step interpolation
+beta.step_interpolation = false  # set to true to turn on the step interpolation
+gamma.step_interpolation = false # set to true to turn on the step interpolation
 delta.step_interpolation = false # set to true to turn on the step interpolation
 
 [tmc2660]
 # settings specific to each tmc2660 driver instance
-alpha.step_interpolation = true # set to true to turn on the step interpolation
-beta.step_interpolation = true  # set to true to turn on the step interpolation
-gamma.step_interpolation = true # set to true to turn on the step interpolation
+alpha.step_interpolation = false # set to true to turn on the step interpolation
+beta.step_interpolation = false  # set to true to turn on the step interpolation
+gamma.step_interpolation = false # set to true to turn on the step interpolation
 delta.step_interpolation = false # set to true to turn on the step interpolation
 
 [current control]

--- a/Firmware/src/modules/tools/endstops/Endstops.cpp
+++ b/Firmware/src/modules/tools/endstops/Endstops.cpp
@@ -186,7 +186,7 @@ bool Endstops::load_endstops(ConfigReader& cr)
         // check we are not going above the number of configured actuators/axis
         if(a >= Robot::getInstance()->get_number_registered_motors()) {
             // too many axis we only have configured n_motors
-            printf("ERROR: configure-endstop: Too many endstops defined for the number of axis\n");
+            printf("WARNING: configure-endstop: Too many endstops defined for the number of axis\n");
             continue;
         }
 

--- a/Firmware/src/modules/tools/endstops/Endstops.cpp
+++ b/Firmware/src/modules/tools/endstops/Endstops.cpp
@@ -370,10 +370,6 @@ void Endstops::read_endstops()
                     } else {
                         // we signal the motor to stop, which will preempt any moves on that axis
                         STEPPER[m]->stop_moving();
-                        // also stop any slaved actuator
-                        if(e.slaved_axis != nullptr) {
-                            e.slaved_axis->stop_moving();
-                        }
                     }
                     e.pin_info->triggered = true;
                 }
@@ -1366,7 +1362,6 @@ bool Endstops::manual_move(uint32_t steps, uint32_t sps, StepperMotor *sa, bool 
         // sa->manual_step(dir);
         // for now we do this hack
         {
-            // set direction if needed
             sa->set_direction(dir);
             sa->step();
             // unstep delay (pulse period) set to 4us here

--- a/Firmware/src/modules/tools/endstops/Endstops.cpp
+++ b/Firmware/src/modules/tools/endstops/Endstops.cpp
@@ -1341,6 +1341,7 @@ bool Endstops::move_slaved_axis(uint8_t paxis, bool adjust, OutputStream& os)
 }
 
 // do a step by step manual move optionally until the pin is hit
+// Used to adjust the slave axis only
 bool Endstops::manual_move(uint32_t steps, uint32_t sps, StepperMotor *sa, bool dir, uint32_t& nsteps, Pin *pin)
 {
     // make sure motors are enabled, as manual step does not check
@@ -1358,17 +1359,7 @@ bool Endstops::manual_move(uint32_t steps, uint32_t sps, StepperMotor *sa, bool 
             break;
         }
 
-        // this won't work as the slave actuator is not registered with the stepticker
-        // sa->manual_step(dir);
-        // for now we do this hack
-        {
-            sa->set_direction(dir);
-            sa->step();
-            // unstep delay (pulse period) set to 4us here
-            uint32_t st = benchmark_timer_start();
-            while(benchmark_timer_as_us(benchmark_timer_elapsed(st)) < 4);
-            sa->unstep();
-        }
+        sa->manual_step(dir);
 
         ++nsteps;
 

--- a/Firmware/src/modules/tools/endstops/Endstops.h
+++ b/Firmware/src/modules/tools/endstops/Endstops.h
@@ -38,7 +38,7 @@ class Endstops : public Module
         bool handle_G28(GCode& gcode, OutputStream& os);
         bool handle_mcode(GCode& gcode, OutputStream& os);
         bool move_slaved_axis(uint8_t paxis, bool adjust, OutputStream& os);
-        bool manual_move(uint32_t steps, uint32_t sps, uint8_t a, bool dir, uint32_t& nsteps, Pin *pin=nullptr);
+        bool manual_move(uint32_t steps, uint32_t sps, StepperMotor *sa, bool dir, uint32_t& nsteps, Pin *pin=nullptr);
 
         // global settings
         uint32_t debounce_ms;
@@ -68,11 +68,10 @@ class Endstops : public Module
             float fast_rate;
             float slow_rate;
             endstop_info_t *pin_info;
-
+            StepperMotor *slaved_axis;
             struct {
                 char axis:8; // one of XYZABC
                 uint8_t axis_index:3;
-                uint8_t slaved_axis_index:3;
                 bool home_direction:1; // true min or false max
                 bool homed:1;
             };

--- a/Firmware/src/robot/Robot.cpp
+++ b/Firmware/src/robot/Robot.cpp
@@ -1950,7 +1950,7 @@ bool Robot::append_milestone(const float target[], float rate_mm_s)
     // find distance moved by each axis, use transformed target from the current compensated machine position
     for (size_t i = 0; i < n_motors; i++) {
         deltas[i] = transformed_target[i] - compensated_machine_position[i];
-        if(deltas[i] == 0) continue;
+        if(std::abs(deltas[i]) < 0.0001F) continue; // try to ignore float hiccups
         // at least one non zero delta
         move = true;
         if(i < N_PRIMARY_AXIS) {
@@ -1964,7 +1964,7 @@ bool Robot::append_milestone(const float target[], float rate_mm_s)
     // see if this is a primary axis move or not
     bool auxilliary_move = true;
     for (int i = 0; i < N_PRIMARY_AXIS; ++i) {
-        if(deltas[i] != 0) {
+        if(std::abs(deltas[i]) >= 0.0001F) {
             auxilliary_move = false;
             break;
         }

--- a/Firmware/src/robot/Robot.cpp
+++ b/Firmware/src/robot/Robot.cpp
@@ -159,7 +159,7 @@ static const char* const actuator_keys[] = {
 #endif
 };
 
-static int find_actuator_key(const char *k)
+int find_actuator_key(const char *k)
 {
     int m = -1;
     for (int i = 0; i < (int)(sizeof(actuator_keys) / sizeof(actuator_keys[0])); ++i) {
@@ -291,6 +291,7 @@ bool Robot::configure(ConfigReader& cr)
 
         // create the actuator
         StepperMotor *sm = new StepperMotor(step_pin, dir_pin, en_pin);
+        sm->set_motor_id(a);
 
 #if defined(DRIVER_TMC)
         // drivers by default for XYZA are internal, BC are by default external

--- a/Firmware/src/robot/Robot.h
+++ b/Firmware/src/robot/Robot.h
@@ -71,7 +71,6 @@ public:
     bool is_homed() const;
     bool can_z_home() const;
     void clear_homed();
-    int8_t get_slaved_to(uint8_t a) const { if((a-3)<3) return slaved[a-3]; else return -1; }
     bool is_must_be_homed() const;
     int get_active_extruder() const;
     bool is_nist_G30() const { return nist_G30; }
@@ -181,12 +180,6 @@ private:
     float park_position[3];
     float saved_position[3];
     bool nist_G30;
-
-    // slaved motors, we can slave A,B,C to X,Y,Z
-    // if -1, then not slaved otherwise it is the motor_id of the motor it is slaved to
-    // this can only be applied to A, B, C and can only be slaved to X, Y, Z
-    // example if A is slaved to Y slaved[0]= 1
-    int8_t slaved[3]{-1, -1, -1};
 
     Pin *motors_enable_pin{nullptr};                      // global enable pin
     uint8_t n_motors;                                    //count of the motors/axis registered

--- a/Firmware/src/robot/StepTicker.cpp
+++ b/Firmware/src/robot/StepTicker.cpp
@@ -165,7 +165,7 @@ _ramfunc_  void StepTicker::step_tick (void)
     }
 
     // if nothing has been setup we ignore the ticks
-    if(!running && !check_forced_steps) {
+    if(!running) {
         // check if anything new available
         if(conveyor->get_next_block(&current_block)) { // returns false if no new block is available
             running = start_next_block(); // returns true if there is at least one motor with steps to issue
@@ -187,7 +187,6 @@ _ramfunc_  void StepTicker::step_tick (void)
         running = false;
         current_tick = 0;
         current_block = nullptr;
-        check_forced_steps = false;
         return;
     }
 
@@ -196,21 +195,6 @@ _ramfunc_  void StepTicker::step_tick (void)
     for (uint8_t m = 0; m < num_motors; m++) {
         auto *cur_motor = motor[m];
         auto& cur_tick_info = current_block->tick_info[m];
-
-        // first check if we have any forced steps
-        if(cur_motor->has_forced_step()) {
-            cur_motor->step();
-            cur_motor->decrement_forced_step();
-            // note this assumes only one axis can have forced steps
-            if(!cur_motor->has_forced_step()) check_forced_steps = false;
-
-            // we stepped so schedule an unstep
-            unstep |= (1 << m);
-            continue; // this will override any moves in the block queue for this motor
-        }
-
-        // we check again in case we had forced steps
-        if(!running) continue;
 
         // normal processing
         if(cur_tick_info.steps_to_move == 0) continue; // not active

--- a/Firmware/src/robot/StepTicker.h
+++ b/Firmware/src/robot/StepTicker.h
@@ -33,7 +33,6 @@ public:
     int register_actuator(StepperMotor* motor);
     float get_frequency() const { return frequency; }
     const Block *get_current_block() const { return current_block; }
-    void set_check_forced_steps() { check_forced_steps= true; }
     bool start();
     bool stop();
 
@@ -72,5 +71,4 @@ private:
 
     volatile bool running{false};
     static bool started;
-    bool check_forced_steps{false};
 };

--- a/Firmware/src/robot/StepperMotor.cpp
+++ b/Firmware/src/robot/StepperMotor.cpp
@@ -88,18 +88,19 @@ void StepperMotor::manual_step(bool dir)
 #include "TMC2590.h"
 #include "TMC26X.h"
 
+extern int find_actuator_key(const char *k);
 bool StepperMotor::vmot= false;
 bool StepperMotor::setup_tmc(ConfigReader& cr, const char *actuator_name, uint32_t type)
 {
     // NOTE axis is only used by the TMC driver to identify itself in the designator field of M911
-    char axis= motor_id<3?'X'+motor_id:'A'+motor_id-3;
-    printf("DEBUG: setting up tmc%lu for %s, axis %c\n", type, actuator_name, axis);
+    char axis= motor_id<3 ? 'X'+motor_id : 'A'+motor_id-3;
+    printf("DEBUG: setup_tmc: setting up tmc%lu for %s, axis %c (%d)\n", type, actuator_name, axis, motor_id);
     if(type == 2590) {
         tmc= new TMC2590(axis);
     }else if(type == 2660){
         tmc= new TMC26X(axis);
     }else{
-        printf("ERROR: tmc%lu is not a valid driver\n", type);
+        printf("ERROR: setup_tmc: tmc%lu is not a valid driver\n", type);
         return false;
     }
 

--- a/Firmware/src/robot/StepperMotor.h
+++ b/Firmware/src/robot/StepperMotor.h
@@ -17,11 +17,22 @@ class StepperMotor
         uint8_t get_motor_id() const { return motor_id; }
 
         // called from step ticker ISR
-        inline bool step() { step_pin.set(1); step_count += (direction?-1:1); return moving; }
+        inline bool step() {
+            step_pin.set(1); step_count += (direction?-1:1);
+            if(p_slave != nullptr) p_slave->step();
+            return moving;
+        }
         // called from unstep ISR
-        inline void unstep() { step_pin.set(0); }
+        inline void unstep() {
+            step_pin.set(0);
+            if(p_slave != nullptr) p_slave->unstep();
+        }
+
         // called from step ticker ISR
-        inline void set_direction(bool f) { dir_pin.set(f); direction= f; }
+        inline void set_direction(bool f) {
+            dir_pin.set(f); direction= f;
+            if(p_slave != nullptr) p_slave->set_direction(f);
+        }
         inline bool get_direction() const { return direction; }
 
         void enable(bool state);
@@ -57,11 +68,18 @@ class StepperMotor
 
         int32_t steps_to_target(float);
 
+        bool has_slave() const { return p_slave != nullptr; }
+        StepperMotor *get_slave() const { return p_slave; }
+        bool init_slave(StepperMotor *sm);
+
     private:
 
         Pin step_pin;
         Pin dir_pin;
         Pin en_pin;
+
+        // if this motor has a slave the pointer to it is set here
+        StepperMotor *p_slave{nullptr};
 
         float steps_per_mm;
         float max_rate; // this is not really rate it is in mm/sec, misnamed used in Robot and Extruder
@@ -97,6 +115,7 @@ class StepperMotor
 
     private:
         uint32_t current_ma{0};
+        uint32_t tmc_type{0};
         // TMCxxxx driver
         TMCBase *tmc{nullptr};
         static bool vmot;

--- a/Firmware/src/robot/StepperMotor.h
+++ b/Firmware/src/robot/StepperMotor.h
@@ -42,8 +42,6 @@ class StepperMotor
         inline void stop_moving() { moving= false; }
 
         void manual_step(bool dir);
-        inline bool has_forced_step() { return forced_steps != 0; }
-        inline void decrement_forced_step() { --forced_steps; }
 
         inline bool which_direction() const { return direction; }
 
@@ -89,7 +87,6 @@ class StepperMotor
         int32_t step_count_homed;
         int32_t last_milestone_steps;
         float   last_milestone_mm;
-        uint32_t forced_steps{0};
 
         volatile struct {
             uint8_t motor_id:8;

--- a/Firmware/src/robot/drivers/TMC2590.cpp
+++ b/Firmware/src/robot/drivers/TMC2590.cpp
@@ -335,16 +335,12 @@ bool TMC2590::config(ConfigReader& cr, const char *actuator_name)
     // the following override the raw register settings if set
     // see if we want step interpolation
     bool interpolation = cr.get_bool(mm, step_interpolation_key, false);
-    if(interpolation) {
-        setStepInterpolation(1);
-        printf("DEBUG: config-tmc2590: %s - step interpolation is on\n", actuator_name);
-    }
+    setStepInterpolation(interpolation?1:0);
+    printf("DEBUG: config-tmc2590: %s - step interpolation is %s\n", actuator_name, interpolation?"on":"off");
 
     bool pfd = cr.get_bool(mm, passive_fast_decay_key, true);
-    if(pfd) {
-        setPassiveFastDecay(1);
-        printf("DEBUG: config-tmc2590: %s - passive fast decay is on\n", actuator_name);
-    }
+    setPassiveFastDecay(pfd?1:0);
+    printf("DEBUG: config-tmc2590: %s - passive fast decay is %s\n", actuator_name, pfd?"on":"off");
 
     // set the standstill current in mA, default is off
     standstill_current= cr.get_int(mm, standstill_current_key, 0);

--- a/Firmware/src/robot/drivers/TMC2590.cpp
+++ b/Firmware/src/robot/drivers/TMC2590.cpp
@@ -211,13 +211,13 @@ bool TMC2590::config(ConfigReader& cr, const char *actuator_name)
     name = actuator_name;
     ConfigReader::sub_section_map_t ssm;
     if(!cr.get_sub_sections("tmc2590", ssm)) {
-        printf("ERROR:config_tmc2590: no tmc2590 section found\n");
+        printf("ERROR: config_tmc2590: no tmc2590 section found\n");
         return false;
     }
 
     auto s = ssm.find(actuator_name);
     if(s == ssm.end()) {
-        printf("ERROR:config_tmc2590: %s - no tmc2590 entry found\n", actuator_name);
+        printf("ERROR: config_tmc2590: %s - no tmc2590 entry found\n", actuator_name);
         return false;
     }
 
@@ -237,11 +237,11 @@ bool TMC2590::config(ConfigReader& cr, const char *actuator_name)
     spi_cs = new Pin(cs_pin.c_str(), Pin::AS_OUTPUT_ON); // set high on creation
     if(!spi_cs->connected()) {
         delete spi_cs;
-        printf("ERROR:config_tmc2590: %s - spi cs pin %s is invalid\n", actuator_name, cs_pin.c_str());
+        printf("ERROR: config_tmc2590: %s - spi cs pin %s is invalid\n", actuator_name, cs_pin.c_str());
         return false;
     }
     spi_cs->set(true);
-    printf("DEBUG:configure-tmc2590: %s - spi cs pin: %s\n", actuator_name, spi_cs->to_string().c_str());
+    printf("DEBUG: config-tmc2590: %s - spi cs pin: %s\n", actuator_name, spi_cs->to_string().c_str());
 
     // if this is the first instance then get any common settings
     if(!common_setup) {
@@ -252,7 +252,7 @@ bool TMC2590::config(ConfigReader& cr, const char *actuator_name)
             if(reset_pin == nullptr) {
                 reset_pin= new Pin(cr.get_string(cm, reset_pin_key, "nc"), Pin::AS_OUTPUT_OFF); // sets low
                 if(reset_pin->connected()) {
-                    printf("DEBUG:configure-tmc2590: reset pin set to: %s\n", reset_pin->to_string().c_str());
+                    printf("DEBUG: config-tmc2590: reset pin set to: %s\n", reset_pin->to_string().c_str());
                     reset_pin->set(true); // sets high turns on all drivers
                 }else{
                     delete reset_pin;
@@ -315,7 +315,7 @@ bool TMC2590::config(ConfigReader& cr, const char *actuator_name)
     // get rest of instance specific configs
     this->resistor = cr.get_int(mm, resistor_key, 50); // in milliohms
     this->max_current = cr.get_int(mm, max_current_key, this->resistor == 75 ? 4400 : this->resistor == 50 ? 5500 : 3200); // milliamps
-    printf("DEBUG:configure-tmc2590: %s - sense resistor: %d milliohms, max current: %ld mA\n", actuator_name, resistor, max_current);
+    printf("DEBUG: config-tmc2590: %s - sense resistor: %d milliohms, max current: %ld mA\n", actuator_name, resistor, max_current);
 
     // if raw registers are defined set them 1,2,3 etc in hex
     std::string str = cr.get_string(mm, raw_register_key, "");
@@ -337,13 +337,13 @@ bool TMC2590::config(ConfigReader& cr, const char *actuator_name)
     bool interpolation = cr.get_bool(mm, step_interpolation_key, false);
     if(interpolation) {
         setStepInterpolation(1);
-        printf("DEBUG:configure-tmc2590: %s - step interpolation is on\n", actuator_name);
+        printf("DEBUG: config-tmc2590: %s - step interpolation is on\n", actuator_name);
     }
 
     bool pfd = cr.get_bool(mm, passive_fast_decay_key, true);
     if(pfd) {
         setPassiveFastDecay(1);
-        printf("DEBUG:configure-tmc2590: %s - passive fast decay is on\n", actuator_name);
+        printf("DEBUG: config-tmc2590: %s - passive fast decay is on\n", actuator_name);
     }
 
     // set the standstill current in mA, default is off
@@ -1308,15 +1308,15 @@ bool TMC2590::set_raw_register(OutputStream& stream, uint32_t reg, uint32_t val)
             send20bits(cool_step_register_value);
             send20bits(stall_guard2_current_register_value);
             send20bits(driver_configuration_register_value);
-            stream.printf("INFO: TMC2590 Registers written\n");
+            stream.printf("INFO: TMC2590 %c: Registers written\n", designator);
             break;
 
 
-        case 1: driver_control_register_value = val; stream.printf("INFO: TMC2590 driver control register set to %05lX\n", val); break;
-        case 2: chopper_config_register_value = val; stream.printf("INFO: TMC2590 chopper config register set to %05lX\n", val); break;
-        case 3: cool_step_register_value = val; stream.printf("INFO: TMC2590 cool step register set to %05lX\n", val); break;
-        case 4: stall_guard2_current_register_value = val; stream.printf("INFO: TMC2590 stall guard2 current register set to %05lX\n", val); break;
-        case 5: driver_configuration_register_value = val; stream.printf("INFO: TMC2590 driver configuration register set to %05lX\n", val); break;
+        case 1: driver_control_register_value = val; stream.printf("INFO: TMC2590 %c: driver control register set to %05lX\n", designator, val); break;
+        case 2: chopper_config_register_value = val; stream.printf("INFO: TMC2590 %c: chopper config register set to %05lX\n", designator, val); break;
+        case 3: cool_step_register_value = val; stream.printf("INFO: TMC2590 %c: cool step register set to %05lX\n", designator, val); break;
+        case 4: stall_guard2_current_register_value = val; stream.printf("INFO: TMC2590 %c: stall guard2 current register set to %05lX\n", designator, val); break;
+        case 5: driver_configuration_register_value = val; stream.printf("INFO: TMC2590 %c: driver configuration register set to %05lX\n", designator, val); break;
 
         default:
             stream.printf("1: driver control register\n");

--- a/Firmware/src/robot/drivers/TMC26X.cpp
+++ b/Firmware/src/robot/drivers/TMC26X.cpp
@@ -326,17 +326,13 @@ bool TMC26X::config(ConfigReader& cr, const char *actuator_name)
     }
 
     // see if we want step interpolation (overrides the raw register setting if set)
-    bool interpolation= cr.get_bool(mm, step_interpolation_key, false);
-    if(interpolation) {
-        setStepInterpolation(1);
-        printf("DEBUG:configure-tmc2660: step interpolation for %s is on\n", actuator_name);
-    }
+    bool interpolation = cr.get_bool(mm, step_interpolation_key, false);
+    setStepInterpolation(interpolation?1:0);
+    printf("DEBUG: config-tmc2660: %s - step interpolation is %s\n", actuator_name, interpolation?"on":"off");
 
     bool pfd = cr.get_bool(mm, passive_fast_decay_key, true);
-    if(pfd) {
-        setPassiveFastDecay(1);
-        printf("DEBUG:configure-tmc26X: %s - passive fast decay is on\n", actuator_name);
-    }
+    setPassiveFastDecay(pfd?1:0);
+    printf("DEBUG: config-tmc2660: %s - passive fast decay is %s\n", actuator_name, pfd?"on":"off");
 
     // set the standstill current in mA, default is off
     standstill_current= cr.get_int(mm, standstill_current_key, 0);


### PR DESCRIPTION
I have relented on the way I was implementing this, which turned out more complex with little to no advantages.

This version echoes step and dir from the stepticker to the slaved actuator, actually the steppermotor step and unstep check if there is a slaved motor and issues a step and unstep to that as well. The downside is it makes the stepticker take a little longer to process steps even if slaving is not used.

The slaved actuator is not seen as an axis motor and does not appear in the actuators array.
The slaved actuator must be the last one defined.
If there is an A/E then the slaved driver must be B, otherwise it can be A.
The slave driver must be exactly the same as the master driver, with the same settings exactly.
M911 will show the slaved driver settings after the masters settings, as the slaved driver cannot be accessed directly.
current setting and other settings will be duplicated to the slave driver when the master driver is set.
Only ABC can be a slave to XYZ, not necessarily in that order though, so Y can have A as a slave.

All actuator settings are ignored for the slave except..

```
[actuator]
...
delta.microsteps = 32       # sets micro stepping (default 32) must be same as master actuator
delta.slaved_to = beta      # delta is slaved to beta(Y)
```

If you do try to set different microsteps you will get a config error on boot.

Most of the changes are in steppermotor, and the config in robot.cpp.
Endstops has had an addition to allow the slave actuator to have an endstop and to allow it to adjust after the axis are homed. Basically the usual homing cycle is done with both actuators moving at the same time. Then a G28.7 Y0 can be issued to see what the offset is between the slaved actuator and its endstop. Then you can set this offset using M666 Ynnn where nnn is the offset for the slave of Y, then G28.7 Y1 issued after homing the main axis will adjust the slaved axis. This does not need to be done every home, just after the actuators have been aligned manually, and if they get out of sync.

There are also some bug fixes for the TMC drivers setting interpolation and passive fast decay from config when overriding register settings.
